### PR TITLE
fixes for recent mvc.net project

### DIFF
--- a/src/jsConnect/Controllers/JsConnectController.cs
+++ b/src/jsConnect/Controllers/JsConnectController.cs
@@ -72,17 +72,6 @@ namespace jsConnect.Controllers
         /// <summary>
         /// Returns details of a currently signed-in user, if any.
         /// </summary>
-        /// <remarks>A backward-compatibility method. Not sure if MVC is capable of redirecting to async method automatically. I'll check that eventually.</remarks>
-        [HttpGet("[action]")]
-        [Produces("application/json")]
-        public ActionResult Authenticate([FromQuery] string client_id, [FromQuery] string callback, [FromQuery] int? timestamp = null, [FromQuery] string signature = null)
-        {
-            return Task.Run(() => AuthenticateAsync(client_id, callback, timestamp, signature)).Result;
-        }
-
-        /// <summary>
-        /// Returns details of a currently signed-in user, if any.
-        /// </summary>
         [HttpGet("[action]")]
         [Produces("application/json")]
         public async Task<ActionResult> AuthenticateAsync([FromQuery] string client_id, [FromQuery] string callback, [FromQuery] int? timestamp = null, [FromQuery] string signature = null)

--- a/src/jsConnect/Extensions.cs
+++ b/src/jsConnect/Extensions.cs
@@ -26,7 +26,11 @@ namespace jsConnect
 			{
 				throw new ArgumentNullException(nameof(o));
 			}
-			return $"{callback}({JsonConvert.SerializeObject(o)})";
+			var settings = new JsonSerializerSettings
+			{
+				NullValueHandling = NullValueHandling.Ignore
+			};
+			return $"{callback}({JsonConvert.SerializeObject(o, Formatting.None, settings)})";
 		}
 
 		/// <summary>


### PR DESCRIPTION
Contains a couple changes that I needed to implement to get it working:
- removes `Authenticate` action since the `AuthenticateAsync` action is automatically routed to
  - closes #14 
- ignores nulls when serializing the jsonp response since it was including stuff like `message=&error=` in the payload but not the signature, resulting in an invalid signature