### PR TITLE
disabling client caching on authentication endpoint, updated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,7 @@ public void ConfigureServices(IServiceCollection services)
 {
 	services
 	.AddMvc() // Or AddControllers, or similar...
-	.AddApplicationPart(typeof(VanillaApiClient).GetTypeInfo().Assembly) // Add the controllers from this
-	.AddJsonOptions(o =>
-	{
-		o.JsonSerializerOptions.PropertyNamingPolicy = null;
-		o.JsonSerializerOptions.IgnoreNullValues = true;
-	});
+	.AddApplicationPart(typeof(VanillaApiClient).GetTypeInfo().Assembly); // Add the controllers from this
 
    services.AddSingleton(Configuration);
    services.AddTransient<HashAlgorithm>(h => SHA512.Create()); // Reflect the hashing algorithm set in Vanilla Forums
@@ -35,7 +30,8 @@ public void ConfigureServices(IServiceCollection services)
    "ClientId": "your_client_id",
    "ClientSecret": "your_secret",
    "TimestampValidFor": "int_seconds",
-   "AllowWhitespaceInUsername": "bool" 
+   "AllowWhitespaceInUsername": "bool",
+   "BaseUri": "http://your-vanilla-forum.com/"
 }
 ```
 **4.** Make sure the `HttpContext.User` has the following claims set according to the [documentation](http://docs.vanillaforums.com/help/sso/jsconnect/seamless/):

--- a/src/jsConnect/Controllers/JsConnectController.cs
+++ b/src/jsConnect/Controllers/JsConnectController.cs
@@ -74,6 +74,7 @@ namespace jsConnect.Controllers
         /// </summary>
         [HttpGet("[action]")]
         [Produces("application/json")]
+        [ResponseCache(NoStore = true, Duration = 0)]
         public async Task<ActionResult> AuthenticateAsync([FromQuery] string client_id, [FromQuery] string callback, [FromQuery] int? timestamp = null, [FromQuery] string signature = null)
         {
             JsConnectResponseModel jsConnectResult = new JsConnectResponseModel();


### PR DESCRIPTION
Ran into intermittent issues with the authentication timestamp being invalid because my browser was caching the jsonp payload, this should fix that. Also removed JSON serialization config from the README and added `BaseUri` since the Vanilla API client doesn't work without it.