### PR TITLE
Auto-merge non-major Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,55 @@
+name: Dependabot auto-merge
+
+# master requires 1 approving review + the codecov status checks, so Dependabot
+# PRs need an approval before auto-merge can pick them up. Non-major updates get
+# approved automatically; auto-merge then waits for the required checks.
+#
+# pull_request_target is used because GITHUB_TOKEN is read-only on Dependabot's
+# pull_request events. No code is checked out here, so the elevated token never
+# runs anything from the PR branch.
+
+on:
+  pull_request_target:
+    branches: [ master ]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Grouped PRs report the highest semver bump in the group, so a group
+      # containing a major update is left for manual review.
+      - name: Approve
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Flag major update for manual review
+        if: >-
+          github.event.action == 'opened' &&
+          steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: |
+          gh pr comment "$PR_URL" --body \
+            "Major version update — not auto-merged. Review and merge manually."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds `.github/workflows/dependabot-auto-merge.yml`.

`master` protection requires 1 approving review plus `codecov/patch` and `codecov/project`, so Dependabot PRs currently sit open until someone approves them by hand. This workflow approves non-major updates as the Actions bot and turns on auto-merge (squash); GitHub then merges once the required checks pass.

- Major bumps (including groups whose highest bump is major) are not auto-merged — they get a comment instead.
- Runs on `pull_request_target` because `GITHUB_TOKEN` is read-only on Dependabot's `pull_request` events. No PR code is checked out, so the elevated token never executes anything from the branch.
- Re-runs on `synchronize`, which re-approves after a Dependabot rebase dismisses the stale review.

Verified beforehand: repo-level "Allow auto-merge" is on, "Allow GitHub Actions to create and approve pull requests" is on, and there is no CODEOWNERS file — so `require_code_owner_reviews` does not block the bot's approval.

Takes effect for new Dependabot PRs once merged to `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)